### PR TITLE
feat (accounts): Adding support for seeding test account

### DIFF
--- a/.github/workflows/cezzis-api-cicd.yaml
+++ b/.github/workflows/cezzis-api-cicd.yaml
@@ -169,3 +169,14 @@ jobs:
           method: PUT
         env:
           AUTH_VALUE: ${{ secrets.PRD_DEVOPS_APIM_SUBSCRIPTION_KEY }}
+
+      - name: Seed test account
+        uses: mtnvencenzo/workflows/.github/actions/api-call@main
+        with:
+          enabled: true
+          url: https://api.cezzis.com/prd/cocktails/api/v1/accounts/test/profile
+          statusCode: 204
+          authHeader: X-Key
+          method: PUT
+        env:
+          AUTH_VALUE: ${{ secrets.PRD_DEVOPS_APIM_SUBSCRIPTION_KEY }}

--- a/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/Account.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/Account.cs
@@ -202,4 +202,9 @@ public class Account : Entity, IAggregateRoot
 
         return this;
     }
+
+    public bool IsTestAccount() => this.LoginEmail.StartsWith("rvecchi+cypress", StringComparison.OrdinalIgnoreCase) ||
+                                   this.LoginEmail.StartsWith("rvecchi+e2e", StringComparison.OrdinalIgnoreCase) ||
+                                   this.LoginEmail.StartsWith("rvecchi+playwright", StringComparison.OrdinalIgnoreCase) &&
+                                   this.LoginEmail.EndsWith("@gmail.com", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/AccountCocktailRatings.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/AccountCocktailRatings.cs
@@ -42,6 +42,23 @@ public class AccountCocktailRatings : Entity
         this.Ratings.Add(new AccountCocktailRatingItem(cocktailId, stars));
         return this;
     }
+
+    public AccountCocktailRatings RemoveRating(string cocktailId, out int? stars)
+    {
+        stars = null;
+
+        Guard.NotNullOrWhiteSpace(cocktailId);
+
+        var rating = this.Ratings.FirstOrDefault(x => x.CocktailId == cocktailId);
+        if (rating != null)
+        {
+            stars = rating.Stars;
+            this.Ratings.Remove(rating);
+        }
+
+        return this;
+    }
+
     public AccountCocktailRatings AddRatings(params AccountCocktailRatingItem[] ratings)
     {
         if (ratings != null)

--- a/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/ClaimsAccount.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/ClaimsAccount.cs
@@ -29,7 +29,7 @@ public class ClaimsAccount : ValueObject
         this.GivenName = claimsIdentity.Claims.FirstOrDefault(x => x.Type == ClaimTypes.GivenName)?.Value;
         Guard.NotNullOrWhiteSpace(this.GivenName, () => new CocktailsApiDomainException($"{nameof(this.GivenName)} cannot be null or empty"));
 
-        this.FamilyName = claimsIdentity.Claims.FirstOrDefault(x => x.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname")?.Value;
+        this.FamilyName = claimsIdentity.Claims.FirstOrDefault(x => x.Type == ClaimTypes.Surname)?.Value;
         Guard.NotNullOrWhiteSpace(this.FamilyName, () => new CocktailsApiDomainException($"{nameof(this.FamilyName)} cannot be null or empty"));
 
         this.Email = claimsIdentity.Claims.FirstOrDefault(x => x.Type == "emails")?.Value;

--- a/src/Cocktails.Api.Domain/Aggregates/CocktailAggregate/Cocktail.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/CocktailAggregate/Cocktail.cs
@@ -450,6 +450,22 @@ public class Cocktail : Entity, IAggregateRoot
         return this;
     }
 
+    public Cocktail DecrementRating(int stars)
+    {
+        if (stars is < 1 or > 5)
+        {
+            throw new CocktailsApiDomainException($"{nameof(stars)} must be between 1 and 5");
+        }
+
+        this.Rating ??= new CocktailRating(0, 0, 0, 0, 0, 0);
+
+        _ = this.Rating.Decrement(stars);
+
+        this.SetModifiedOn(DateTimeOffset.Now);
+
+        return this;
+    }
+
     public string RegenerateHash()
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(

--- a/src/Cocktails.Api.Domain/Aggregates/CocktailAggregate/CocktailRating.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/CocktailAggregate/CocktailRating.cs
@@ -95,6 +95,39 @@ public class CocktailRating : ValueObject
         return this;
     }
 
+    public CocktailRating Decrement(int stars)
+    {
+        if (stars is < 1 or > 5)
+        {
+            throw new CocktailsApiDomainException($"{nameof(stars)} must be between 1 and 5");
+        }
+
+        if (stars == 1)
+        {
+            this.OneStars--;
+        }
+        else if (stars == 2)
+        {
+            this.TwoStars--;
+        }
+        else if (stars == 3)
+        {
+            this.ThreeStars--;
+        }
+        else if (stars == 4)
+        {
+            this.FourStars--;
+        }
+        else if (stars == 5)
+        {
+            this.FiveStars--;
+        }
+
+        this.RatingCount--;
+
+        return this;
+    }
+
     protected override IEnumerable<object> GetEqualityComponents()
     {
         yield return this.OneStars;

--- a/src/Cocktails.Api.Domain/Config/TestAccountConfig.cs
+++ b/src/Cocktails.Api.Domain/Config/TestAccountConfig.cs
@@ -1,0 +1,26 @@
+namespace Cocktails.Api.Domain.Config;
+
+public class TestAccountConfig
+{
+    public const string SectionName = "TestAccount";
+
+    public string GivenName { get; set; }
+
+    public string FamilyName { get; set; }
+
+    public string DisplayName { get; set; }
+
+    public string SubjectId { get; set; }
+
+    public string LoginEmail { get; set; }
+
+    public string AddressLine1 { get; set; }
+
+    public string City { get; set; }
+
+    public string Region { get; set; }
+
+    public string PostalCode { get; set; }
+
+    public string Country { get; set; }
+}

--- a/src/Cocktails.Api.Infrastructure/Repositories/AccountRepository.cs
+++ b/src/Cocktails.Api.Infrastructure/Repositories/AccountRepository.cs
@@ -43,8 +43,8 @@ public class AccountRepository(AccountDbContext dbContext) : IAccountRepository
     {
         var claimsAccount = new ClaimsAccount(claimsIdentity);
 
-        var account = await (this.Items
-            .WithPartitionKey(claimsAccount.SubjectId))
+        var account = await this.Items
+            .WithPartitionKey(claimsAccount.SubjectId)
             .FirstOrDefaultAsync(x => x.SubjectId == claimsAccount.SubjectId, cancellationToken);
 
         if (account != null)

--- a/src/Cocktails.Api/Apis/Accounts/AccountsApi.cs
+++ b/src/Cocktails.Api/Apis/Accounts/AccountsApi.cs
@@ -90,6 +90,12 @@ public static class AccountsApi
             .RequireScope("Account.Read")
             .RequireScope("Account.Write");
 
+        groupBuilder.MapPut("/test/profile", SeedTestAccount)
+            .AllowAnonymous()
+            .WithName(nameof(SeedTestAccount))
+            .WithDisplayName(nameof(SeedTestAccount))
+            .WithDescription("Seeds the test account profile for e2e testing purposes");
+
         return groupBuilder;
     }
 
@@ -114,7 +120,7 @@ public static class AccountsApi
 
         var result = await accountServices.Mediator.Send(command);
 
-        return TypedResults.Created<UploadProfileImageRs>(result.ImageUri, result);
+        return TypedResults.Created(result.ImageUri, result);
     }
 
     /// <summary>Updates the account profile for the user represented within the authenticated bearer token</summary>
@@ -127,7 +133,7 @@ public static class AccountsApi
 
         var result = await accountServices.Mediator.Send(command);
 
-        return TypedResults.Ok<AccountOwnedProfileRs>(result);
+        return TypedResults.Ok(result);
     }
 
     /// <summary>Updates the account profile email address for the user represented within the authenticated bearer token</summary>
@@ -140,7 +146,7 @@ public static class AccountsApi
 
         var result = await accountServices.Mediator.Send(command);
 
-        return TypedResults.Ok<AccountOwnedProfileRs>(result);
+        return TypedResults.Ok(result);
     }
 
     /// <summary>Updates the account profile accessibility settings for the user represented within the authenticated bearer token</summary>
@@ -153,7 +159,7 @@ public static class AccountsApi
 
         var result = await accountServices.Mediator.Send(command);
 
-        return TypedResults.Ok<AccountOwnedProfileRs>(result);
+        return TypedResults.Ok(result);
     }
 
     /// <summary>Manages the account profile favorite cocktails for the user represented within the authenticated bearer token</summary>
@@ -166,7 +172,7 @@ public static class AccountsApi
 
         var result = await accountServices.Mediator.Send(command);
 
-        return TypedResults.Ok<AccountOwnedProfileRs>(result);
+        return TypedResults.Ok(result);
     }
 
     /// <summary>Rates a cocktail for the account profile user represented within the authenticated bearer token</summary>
@@ -187,7 +193,7 @@ public static class AccountsApi
             return TypedResults.Conflict<ProblemDetails>(ProblemDetailsExtensions.CreateValidationProblemDetails("Cocktail already rated", 409));
         }
 
-        return TypedResults.Created<RateCocktailRs>("", result);
+        return TypedResults.Created("", result);
     }
 
     /// <summary>Gets the account cocktail ratings for the account profile user represented within the authenticated bearer token</summary>
@@ -216,10 +222,22 @@ public static class AccountsApi
 
         if (!commandResult)
         {
-            return TypedResults.Json<ProblemDetails>(ProblemDetailsExtensions.CreateValidationProblemDetails("Failed to send recommendation", StatusCodes.Status502BadGateway), statusCode: StatusCodes.Status502BadGateway);
+            return TypedResults.Json(ProblemDetailsExtensions.CreateValidationProblemDetails("Failed to send recommendation", StatusCodes.Status502BadGateway), statusCode: StatusCodes.Status502BadGateway);
         }
 
         return TypedResults.Accepted(string.Empty);
     }
 
+    [ProducesDefaultResponseType(typeof(ProblemDetails))]
+    public async static Task<Results<NoContent, JsonHttpResult<ProblemDetails>>> SeedTestAccount([AsParameters] AccountsServices accountServices)
+    {
+        var commandResult = await accountServices.Mediator.Send(new SeedTestAccountCommand(), accountServices.HttpContextAccessor.HttpContext.RequestAborted);
+
+        if (!commandResult)
+        {
+            return TypedResults.Json(ProblemDetailsExtensions.CreateValidationProblemDetails("Failed to seed test account", StatusCodes.Status502BadGateway), statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        return TypedResults.NoContent();
+    }
 }

--- a/src/Cocktails.Api/Apis/Cockails/CocktailsApi.cs
+++ b/src/Cocktails.Api/Apis/Cockails/CocktailsApi.cs
@@ -1,11 +1,9 @@
 ﻿namespace Cocktails.Api.Apis.Cockails;
 
 using Cocktails.Api.Application.Exceptions;
-//using Cocktails.Api.Application.Filters;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using Cocktails.Api.Application.Concerns.Cocktails.Commands;
 using Cocktails.Api.Application.Concerns.Cocktails.Models;
 

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/CocktailRecommendationCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/CocktailRecommendationCommand.cs
@@ -3,8 +3,6 @@
 using Cezzi.Security.Recaptcha;
 using FluentValidation;
 using global::Cocktails.Api.Application.Behaviors;
-using global::Cocktails.Api.Application.Concerns.Cocktails.Models;
-using global::Cocktails.Api.Application.Concerns.RecaptchaVerification;
 using global::Cocktails.Api.Application.IntegrationEvents;
 using global::Cocktails.Api.Domain.Config;
 using global::Cocktails.Api.Domain.Services;
@@ -12,8 +10,6 @@ using global::Cocktails.Api.Domain;
 using global::Cocktails.Common;
 using MediatR;
 using Microsoft.Extensions.Options;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel;
 using global::Cocktails.Common.Emails;
 using FluentValidation.Results;
 using global::Cocktails.Api.Application.Concerns.RecaptchaVerification.Commands;

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ManageFavoriteCocktailsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ManageFavoriteCocktailsCommand.cs
@@ -2,15 +2,8 @@
 
 using Cezzi.Applications;
 using global::Cocktails.Api.Application.Concerns.Accounts.Models;
-using global::Cocktails.Api.Domain;
 using global::Cocktails.Api.Domain.Aggregates.AccountAggregate;
-using global::Cocktails.Api.Domain.Config;
-using global::Cocktails.Api.Domain.Services;
-using global::Cocktails.Common;
 using MediatR;
-using Microsoft.Extensions.Options;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 
 public record ManageFavoriteCocktailsCommand

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/SeedTestAccountCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/SeedTestAccountCommand.cs
@@ -1,0 +1,67 @@
+﻿namespace Cocktails.Api.Application.Concerns.Accounts.Commands;
+
+using MediatR;
+using global::Cocktails.Api.Domain.Config;
+using Microsoft.Extensions.Options;
+using global::Cocktails.Api.Application.Concerns.Accounts.Models;
+using System.Security.Claims;
+using global::Cocktails.Api.Application.Concerns.Accounts.Queries;
+
+public record SeedTestAccountCommand() : IRequest<bool>;
+
+public class SeedTestAccountCommandHandler(
+    IMediator mediator,
+    IOptions<TestAccountConfig> testAccountConfig,
+    IAccountsQueries accountsQueries) : IRequestHandler<SeedTestAccountCommand, bool>
+{
+    public async Task<bool> Handle(SeedTestAccountCommand command, CancellationToken cancellationToken)
+    {
+        var identity = new ClaimsIdentity([
+            new (ClaimTypes.NameIdentifier, testAccountConfig.Value.SubjectId),
+            new (ClaimTypes.Name, testAccountConfig.Value.DisplayName),
+            new (ClaimTypes.GivenName, testAccountConfig.Value.GivenName),
+            new (ClaimTypes.Surname, testAccountConfig.Value.FamilyName),
+            new ("emails", testAccountConfig.Value.LoginEmail ?? testAccountConfig.Value.LoginEmail)
+        ]);
+
+        var updateAccountProfileCommand = new UpdateAccountOwnedProfileCommand(
+            Request: new UpdateAccountOwnedProfileRq(
+                GivenName: testAccountConfig.Value.GivenName,
+                FamilyName: testAccountConfig.Value.FamilyName,
+                DisplayName: testAccountConfig.Value.DisplayName,
+                PrimaryAddress: new AccountAddressModel(
+                    AddressLine1: testAccountConfig.Value.AddressLine1,
+                    AddressLine2: "",
+                    City: testAccountConfig.Value.City,
+                    Region: testAccountConfig.Value.Region,
+                    SubRegion: "",
+                    PostalCode: testAccountConfig.Value.PostalCode,
+                    Country: testAccountConfig.Value.Country)),
+            Identity: identity);
+
+        var _ = await mediator.Send(updateAccountProfileCommand, cancellationToken)
+            ?? throw new InvalidOperationException("Failed to update test account profile.");
+
+        var updateEmailCommand = new UpdateAccountOwnedProfileEmailCommand(
+            Request: new UpdateAccountOwnedProfileEmailRq(Email: testAccountConfig.Value.LoginEmail),
+            Identity: identity);
+
+        _ = await mediator.Send(updateEmailCommand, cancellationToken)
+            ?? throw new InvalidOperationException("Failed to update test account email.");
+
+        // If the account has favorite cocktails, start fresh and remove them
+        var favorites = (await accountsQueries.GetAccountOwnedProfile(identity, cancellationToken)).FavoriteCocktails ?? [];
+
+        if (favorites.Count > 0)
+        {
+            var manageFavoriteCocktailsCommand = new ManageFavoriteCocktailsCommand(
+                Request: new ManageFavoriteCocktailsRq(CocktailActions: favorites.Select(c => new CocktailFavoriteActionModel(CocktailId: c, Action: CocktailFavoritingActionModel.Remove)).ToList()),
+                Identity: identity);
+
+            _ = await mediator.Send(manageFavoriteCocktailsCommand, cancellationToken)
+                ?? throw new InvalidOperationException("Failed to remove existing favorite cocktails from test account.");
+        }
+
+        return true;
+    }
+}

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UnRateCocktailCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UnRateCocktailCommand.cs
@@ -1,0 +1,110 @@
+﻿namespace Cocktails.Api.Application.Concerns.Accounts.Commands;
+
+using Cezzi.Applications;
+using global::Cocktails.Api.Application.Concerns.Accounts.Models;
+using global::Cocktails.Api.Application.IntegrationEvents;
+using global::Cocktails.Api.Domain;
+using global::Cocktails.Api.Domain.Aggregates.AccountAggregate;
+using global::Cocktails.Api.Domain.Aggregates.CocktailAggregate;
+using global::Cocktails.Api.Domain.Config;
+using global::Cocktails.Api.Domain.Services;
+using global::Cocktails.Common;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+
+#pragma warning disable format
+
+public record UnRateCocktailCommand(string CocktailId, ClaimsIdentity Identity) : IRequest<bool>;
+
+public class UnRateCocktailCommandHandler(
+    IAccountRepository accountRepository,
+    ICocktailRepository cocktailRepository,
+    IAccountCocktailRatingsRepository accountCocktailRatingsRepository,
+    IEventBus eventBus,
+    IOptions<PubSubConfig> pubSubConfig,
+    ILogger<UnRateCocktailCommandHandler> logger) : IRequestHandler<UnRateCocktailCommand, bool>
+{
+    public async Task<bool> Handle(UnRateCocktailCommand command, CancellationToken cancellationToken)
+    {
+        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+            claimsIdentity: command.Identity,
+            cancellationToken: cancellationToken);
+
+        using var scope = logger.BeginScope(new Dictionary<string, object>
+        {
+            { Monikers.Account.AccountId, account?.Id },
+            { Monikers.Account.SubjectId, account?.SubjectId },
+            { Monikers.Cocktails.CocktailId, command?.CocktailId }
+        });
+
+        Guard.NotNull(account);
+
+        var accountCocktailRatings = !string.IsNullOrWhiteSpace(account.SubjectId)
+            ? await accountCocktailRatingsRepository.Items
+                .WithPartitionKey(account.SubjectId)
+                .Where(x => !string.IsNullOrWhiteSpace(account.RatingsId) || x.Id == account.RatingsId)
+                .Where(x => x.SubjectId == account.SubjectId)
+                .FirstOrDefaultAsync()
+            : null;
+
+        if (accountCocktailRatings == null && !accountCocktailRatings.Ratings.Any(x => x.CocktailId == command.CocktailId))
+        {
+            logger.LogWarning("Cocktail has not been rated");
+            return false;
+        }
+
+        var cocktail = cocktailRepository.CachedItems.FirstOrDefault(x => x.Id == command.CocktailId);
+
+        if (cocktail == null)
+        {
+            // cocktail not found
+            logger.LogWarning("Cocktail not found to un rate");
+            return false;
+        }
+
+        accountCocktailRatings.RemoveRating(command.CocktailId, out var stars);
+        if (stars == null)
+        {
+            logger.LogWarning("Cocktail has not been rated");
+            return false;
+        }
+
+        await accountCocktailRatingsRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
+
+        var cocktailRatingEvent = new CocktailRatingEvent(
+            ownedAccountId: account.Id,
+            ownedAccountSubjectId: account.SubjectId,
+            cocktailId: command.CocktailId,
+            stars: stars.Value)
+            {
+                DecrementRating = true
+            };
+
+        try
+        {
+            await eventBus.PublishAsync(
+                @event: cocktailRatingEvent,
+                messageLabel: "cocktail-ratings-svc",
+                contentType: "application/json",
+                configName: pubSubConfig.Value.CocktailRatingPublisher.DaprBuildingBlock,
+                topicName: pubSubConfig.Value.CocktailRatingPublisher.TopicName,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            var rawMessage = EventSerializer.ToJsonString(cocktailRatingEvent);
+
+            using var messageScope = logger.BeginScope(new Dictionary<string, object>
+            {
+                { Monikers.App.ObjectGraph, rawMessage }
+            });
+
+            logger.LogCritical(ex, "Failed to send cocktail rating to topic");
+        }
+
+        return true;
+    }
+}

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedAccessibilitySettingsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedAccessibilitySettingsCommand.cs
@@ -2,16 +2,8 @@
 
 using Cezzi.Applications;
 using global::Cocktails.Api.Application.Concerns.Accounts.Models;
-using global::Cocktails.Api.Application.IntegrationEvents;
-using global::Cocktails.Api.Domain;
 using global::Cocktails.Api.Domain.Aggregates.AccountAggregate;
-using global::Cocktails.Api.Domain.Config;
-using global::Cocktails.Api.Domain.Services;
-using global::Cocktails.Common;
 using MediatR;
-using Microsoft.Extensions.Options;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 
 public record UpdateAccountOwnedAccessibilitySettingsCommand

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileCommand.cs
@@ -10,8 +10,6 @@ using global::Cocktails.Api.Domain.Services;
 using global::Cocktails.Common;
 using MediatR;
 using Microsoft.Extensions.Options;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 
 public record UpdateAccountOwnedProfileCommand

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileEmailCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileEmailCommand.cs
@@ -2,15 +2,8 @@
 
 using Cezzi.Applications;
 using global::Cocktails.Api.Application.Concerns.Accounts.Models;
-using global::Cocktails.Api.Domain;
 using global::Cocktails.Api.Domain.Aggregates.AccountAggregate;
-using global::Cocktails.Api.Domain.Config;
-using global::Cocktails.Api.Domain.Services;
-using global::Cocktails.Common;
 using MediatR;
-using Microsoft.Extensions.Options;
-using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 
 public record UpdateAccountOwnedProfileEmailCommand

--- a/src/Cocktails.Api/Program.cs
+++ b/src/Cocktails.Api/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using System.Diagnostics;
 using MediatR;
 using Cocktails.Api.Application.Concerns.Cocktails.Commands;
+using Cocktails.Api.Application.Concerns.Accounts.Commands;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
@@ -43,6 +44,7 @@ if (app.Environment.IsEnvironment("local"))
     var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
     await mediator.Send(new SeedIngredientsCommand(OnlyIfEmpty: true));
     await mediator.Send(new SeedCocktailsCommand(OnlyIfEmpty: true));
+    await mediator.Send(new SeedTestAccountCommand());
 }
 
 // Use cloud events to automatically unpack the message data

--- a/src/Cocktails.Api/StartupExtensions/ApplicationServiceExtensions.cs
+++ b/src/Cocktails.Api/StartupExtensions/ApplicationServiceExtensions.cs
@@ -43,6 +43,7 @@ internal static class ApplicationServiceExtensions
         builder.Services.Configure<MsGraphConfig>(builder.Configuration.GetSection(MsGraphConfig.SectionName));
         builder.Services.Configure<ScalarConfig>(builder.Configuration.GetSection(ScalarConfig.SectionName));
         builder.Services.Configure<SearchConfig>(builder.Configuration.GetSection(SearchConfig.SectionName));
+        builder.Services.Configure<TestAccountConfig>(builder.Configuration.GetSection(TestAccountConfig.SectionName));
 
         builder.Services.AddCosomsContexts();
 

--- a/src/Cocktails.Api/appsettings.json
+++ b/src/Cocktails.Api/appsettings.json
@@ -104,5 +104,18 @@
     "IndexName": "",
     "QueryKey": "",
     "UseSearchIndex": "false"
+  },
+  "TestAccount": {
+    "SubjectId": "41598664-1466-4e3e-b28c-dfe9837e462e",
+    "LoginEmail": "rvecchi+cypress@gmail.com",
+    "Email": "rvecchi+cypress@gmail.com",
+    "GivenName": "Cypress",
+    "FamilyName": "User",
+    "DisplayName": "Cypress Dude",
+    "AddressLine1": "1234 Forgotten Ln",
+    "City": "Any Town",
+    "Region": "MS",
+    "PostalCode": "38607",
+    "Country": "United States"
   }
 }

--- a/terraform/apim-api.tf
+++ b/terraform/apim-api.tf
@@ -230,13 +230,21 @@ module "apim_cocktails_api" {
       policy_xml_content  = local.apim_anonomous_operation_policy
     },
     {
-      display_name        = "Send Recommendation"
+      display_name        = "Post Send Recommendation"
       method              = "POST"
       url_template        = "/accounts/owned/profile/cocktails/recommendations"
       description         = "Send a cocktail recommendation"
       success_status_code = 202
       policy_xml_content  = local.apim_anonomous_operation_policy
-    }
+    },
+    {
+      display_name        = "Put Test Account"
+      method              = "PUT"
+      url_template        = "/accounts/test/profile"
+      description         = "Seeds and resets the e2e test account profile with default values"
+      success_status_code = 204
+      policy_xml_content  = local.apim_anonomous_operation_policy
+    },
   ]
 
   depends_on = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - PUT /accounts/test/profile endpoint to seed/reset the test account (204).
  - Ability to remove a cocktail rating (un-rate) and propagate decremented ratings.
  - Local startup will auto-seed a test account in local environment.
- Chores
  - CI now seeds the test account during PRD verification.
  - API gateway updated with operation for the test account endpoint.
  - Added configurable TestAccount settings to app configuration.
- Refactor
  - Cleaned up response typing and import reductions across the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->