### PR TITLE
feat (notifications): Adding endpoint to save account notifications

### DIFF
--- a/src/Cocktails.Api/Apis/Accounts/AccountsApi.cs
+++ b/src/Cocktails.Api/Apis/Accounts/AccountsApi.cs
@@ -92,9 +92,17 @@ public static class AccountsApi
 
         groupBuilder.MapPut("/test/profile", SeedTestAccount)
             .AllowAnonymous()
+            .ExcludeFromDescription()
             .WithName(nameof(SeedTestAccount))
             .WithDisplayName(nameof(SeedTestAccount))
             .WithDescription("Seeds the test account profile for e2e testing purposes");
+
+        groupBuilder.MapPut("/owned/profile/notifications", UpdateAccountOwnedNotificationSettings)
+            .WithName(nameof(UpdateAccountOwnedNotificationSettings))
+            .WithDisplayName(nameof(UpdateAccountOwnedNotificationSettings))
+            .WithDescription("Updates the account profile notifications settings for the user represented within the authenticated bearer token")
+            .RequireScope("Account.Read")
+            .RequireScope("Account.Write");
 
         return groupBuilder;
     }
@@ -102,7 +110,8 @@ public static class AccountsApi
     /// <summary>Gets the account profile for the user represented within the authenticated bearer token</summary>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> GetAccountOwnedProfile([AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> GetAccountOwnedProfile(
+        [AsParameters] AccountsServices accountServices)
     {
         var rs = await accountServices.Queries.GetAccountOwnedProfile(
             claimsIdentity: accountServices.HttpContextAccessor.HttpContext.User?.Identity as ClaimsIdentity,
@@ -114,7 +123,9 @@ public static class AccountsApi
     /// <summary>Uploads an account profile image for to the user represented within the authenticated bearer token</summary>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Created<UploadProfileImageRs>, JsonHttpResult<ProblemDetails>>> UploadProfileImage(IFormFile file, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Created<UploadProfileImageRs>, JsonHttpResult<ProblemDetails>>> UploadProfileImage(
+        IFormFile file,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new ProfileImageUploadCommand(file, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
 
@@ -127,7 +138,9 @@ public static class AccountsApi
     /// <param name="request">The account profile information to update</param>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedProfile([FromBody] UpdateAccountOwnedProfileRq request, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedProfile(
+        [FromBody, Required, Description("The account profile update request body")] UpdateAccountOwnedProfileRq request,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new UpdateAccountOwnedProfileCommand(request, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
 
@@ -140,7 +153,9 @@ public static class AccountsApi
     /// <param name="request">The account profile email information to update</param>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedProfileEmail([FromBody] UpdateAccountOwnedProfileEmailRq request, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedProfileEmail(
+        [FromBody, Required, Description("The account profile email update request body")] UpdateAccountOwnedProfileEmailRq request,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new UpdateAccountOwnedProfileEmailCommand(request, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
 
@@ -153,7 +168,9 @@ public static class AccountsApi
     /// <param name="request">The account profile accessibility settings to update</param>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedAccessibilitySettings([FromBody] UpdateAccountOwnedAccessibilitySettingsRq request, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedAccessibilitySettings(
+        [FromBody, Required, Description("The account accessibility settings request body")] UpdateAccountOwnedAccessibilitySettingsRq request,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new UpdateAccountOwnedAccessibilitySettingsCommand(request, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
 
@@ -166,7 +183,9 @@ public static class AccountsApi
     /// <param name="request">The cocktails to add or remove from the faviorites list</param>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> ManageFavoriteCocktails([FromBody] ManageFavoriteCocktailsRq request, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> ManageFavoriteCocktails(
+        [FromBody, Required, Description("The favorite cocktails management request body")] ManageFavoriteCocktailsRq request,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new ManageFavoriteCocktailsCommand(request, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
 
@@ -179,7 +198,9 @@ public static class AccountsApi
     /// <param name="request">The cocktails and rating request</param>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Created<RateCocktailRs>, JsonHttpResult<ProblemDetails>, Conflict<ProblemDetails>>> RateCocktail([FromBody] RateCocktailRq request, [AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Created<RateCocktailRs>, JsonHttpResult<ProblemDetails>, Conflict<ProblemDetails>>> RateCocktail(
+        [FromBody, Required, Description("The cocktail rating request body")] RateCocktailRq request,
+        [AsParameters] AccountsServices accountServices)
     {
         var command = new RateCocktailCommand(
             CocktailId: request.CocktailId,
@@ -199,7 +220,8 @@ public static class AccountsApi
     /// <summary>Gets the account cocktail ratings for the account profile user represented within the authenticated bearer token</summary>
     /// <returns></returns>
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<Ok<AccountCocktailRatingsRs>, JsonHttpResult<ProblemDetails>>> GetCocktailRatings([AsParameters] AccountsServices accountServices)
+    public async static Task<Results<Ok<AccountCocktailRatingsRs>, JsonHttpResult<ProblemDetails>>> GetCocktailRatings(
+        [AsParameters] AccountsServices accountServices)
     {
         var rs = await accountServices.Queries.GetAccountOwnedCocktailRatings(
             claimsIdentity: accountServices.HttpContextAccessor.HttpContext.User?.Identity as ClaimsIdentity,
@@ -229,7 +251,8 @@ public static class AccountsApi
     }
 
     [ProducesDefaultResponseType(typeof(ProblemDetails))]
-    public async static Task<Results<NoContent, JsonHttpResult<ProblemDetails>>> SeedTestAccount([AsParameters] AccountsServices accountServices)
+    public async static Task<Results<NoContent, JsonHttpResult<ProblemDetails>>> SeedTestAccount(
+        [AsParameters] AccountsServices accountServices)
     {
         var commandResult = await accountServices.Mediator.Send(new SeedTestAccountCommand(), accountServices.HttpContextAccessor.HttpContext.RequestAborted);
 
@@ -240,4 +263,20 @@ public static class AccountsApi
 
         return TypedResults.NoContent();
     }
+
+    /// <summary>Updates the account profile notifications settings for the user represented within the authenticated bearer token</summary>
+    /// <param name="request">The account profile notification settings to update</param>
+    /// <returns></returns>
+    [ProducesDefaultResponseType(typeof(ProblemDetails))]
+    public async static Task<Results<Ok<AccountOwnedProfileRs>, JsonHttpResult<ProblemDetails>>> UpdateAccountOwnedNotificationSettings(
+        [FromBody, Required, Description("The account notifications request body")] UpdateAccountOwnedNotificationSettingsRq request,
+        [AsParameters] AccountsServices accountServices)
+    {
+        var command = new UpdateAccountOwnedNotificationSettingsCommand(request, accountServices.HttpContextAccessor.HttpContext?.User?.Identity as ClaimsIdentity);
+
+        var result = await accountServices.Mediator.Send(command);
+
+        return TypedResults.Ok(result);
+    }
+
 }

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedNotificationSettingsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedNotificationSettingsCommand.cs
@@ -1,0 +1,42 @@
+﻿namespace Cocktails.Api.Application.Concerns.Accounts.Commands;
+
+using Cezzi.Applications;
+using global::Cocktails.Api.Application.Concerns.Accounts.Models;
+using global::Cocktails.Api.Domain.Aggregates.AccountAggregate;
+using MediatR;
+using System.Security.Claims;
+
+public record UpdateAccountOwnedNotificationSettingsCommand
+(
+    UpdateAccountOwnedNotificationSettingsRq Request,
+
+    ClaimsIdentity Identity
+
+) : IRequest<AccountOwnedProfileRs>;
+
+public class UpdateAccountOwnedNotificationSettingsCommandHandler(IAccountRepository accountRepository)
+    : IRequestHandler<UpdateAccountOwnedNotificationSettingsCommand, AccountOwnedProfileRs>
+{
+    public async Task<AccountOwnedProfileRs> Handle(UpdateAccountOwnedNotificationSettingsCommand command, CancellationToken cancellationToken)
+    {
+        Guard.NotNull(command, nameof(command));
+        Guard.NotNull(command.Request, nameof(command.Request));
+
+        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+            claimsIdentity: command.Identity,
+            cancellationToken: cancellationToken);
+
+        Guard.NotNull(account);
+
+        account.SetOnNewCocktailAdditionsNotification(
+            onNewCocktailAdditions: Enum.Parse<CocktailUpdatedNotification>(command.Request.OnNewCocktailAdditions.ToString()));
+
+        account.SetUpdatedOn(modifiedOn: DateTimeOffset.Now);
+
+        accountRepository.Update(account);
+
+        _ = await accountRepository.UnitOfWork.SaveEntitiesAsync(cancellationToken);
+
+        return AccountOwnedProfileRs.FromAccount(account);
+    }
+}

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Models/UpdateAccountOwnedNotificationSettingsRq.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Models/UpdateAccountOwnedNotificationSettingsRq.cs
@@ -1,0 +1,15 @@
+﻿namespace Cocktails.Api.Application.Concerns.Accounts.Models;
+
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+#pragma warning disable format
+
+[type: Description("The account owned profile notification settings")]
+public record UpdateAccountOwnedNotificationSettingsRq
+(
+    // <example>always</example>
+    [property: Required()]
+    [property: Description("The notification setting to use when new cocktail addtions are added")]
+    CocktailUpdatedNotificationModel OnNewCocktailAdditions
+);

--- a/test/Cocktails.Api.Unit.Tests/Apis/Accounts/UpdateAccountOwnedNotificationSettings_Tests.cs
+++ b/test/Cocktails.Api.Unit.Tests/Apis/Accounts/UpdateAccountOwnedNotificationSettings_Tests.cs
@@ -16,12 +16,12 @@ using global::Cocktails.Api.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-public class UpdateAccountOwnedAccessibilitySettings_Tests : ServiceTestBase
+public class UpdateAccountOwnedNotificationSettings_Tests : ServiceTestBase
 {
-    public UpdateAccountOwnedAccessibilitySettings_Tests() { }
+    public UpdateAccountOwnedNotificationSettings_Tests() { }
 
     [Fact]
-    public async Task updateaccessibilitysettings__returns_matching_account()
+    public async Task updatenotificationsettings__returns_matching_account()
     {
         // Arrange
         var faker = new Faker();
@@ -35,9 +35,9 @@ public class UpdateAccountOwnedAccessibilitySettings_Tests : ServiceTestBase
         var accounts = new List<Account> { unmatchedAccount, account };
         this.accountDbContextMock.Setup(x => x.Accounts).ReturnsDbSet(accounts);
 
-        var request = new UpdateAccountOwnedAccessibilitySettingsRq
+        var request = new UpdateAccountOwnedNotificationSettingsRq
         (
-            Theme: faker.PickRandom<DisplayThemeModel>()
+            OnNewCocktailAdditions: faker.PickRandom<CocktailUpdatedNotificationModel>()
         );
 
         var updatedAccount = this.GetUpdatedAccount(account, request);
@@ -50,27 +50,27 @@ public class UpdateAccountOwnedAccessibilitySettings_Tests : ServiceTestBase
         var services = GetAsParameterServices<AccountsServices>(sp);
 
         // act
-        var response = await AccountsApi.UpdateAccountOwnedAccessibilitySettings(request, services);
+        var response = await AccountsApi.UpdateAccountOwnedNotificationSettings(request, services);
         var result = response.Result as Ok<AccountOwnedProfileRs>;
 
         // assert
         result.Should().NotBeNull();
         result.StatusCode.Should().Be(StatusCodes.Status200OK);
         result.Value.Should().BeEquivalentTo(AccountOwnedProfileRs.FromAccount(updatedAccount));
-        result.Value.Accessibility.Theme.Should().Be(request.Theme);
+        result.Value.Notifications.OnNewCocktailAdditions.Should().Be(request.OnNewCocktailAdditions);
 
         mockRepo.Verify(x => x.Update(It.Is<Account>(a => a.Id == account.Id)), Times.Once);
         mockRepo.Verify(x => x.UnitOfWork.SaveEntitiesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    private Account GetUpdatedAccount(Account account, UpdateAccountOwnedAccessibilitySettingsRq request)
+    private Account GetUpdatedAccount(Account account, UpdateAccountOwnedNotificationSettingsRq request)
     {
         var js = System.Text.Json.JsonSerializer.Serialize(account);
         var newAccount = System.Text.Json.JsonSerializer.Deserialize<Account>(js);
 
-        var theme = Enum.Parse<AccessibilityTheme>(request.Theme.ToString());
+        var onNewCocktailAdditions = Enum.Parse<CocktailUpdatedNotification>(request.OnNewCocktailAdditions.ToString());
 
-        newAccount.SetAccessibilitySettings(theme);
+        newAccount.SetOnNewCocktailAdditionsNotification(onNewCocktailAdditions);
 
         return newAccount;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an endpoint for updating your account notification settings (e.g., notifications for new cocktail additions).

- Documentation
  - Hid the test account seeding route from public API docs.
  - Improved request body descriptions across account-related endpoints for clearer API documentation.

- Tests
  - Added unit tests covering the new notification settings update.
  - Enhanced accessibility settings tests to verify theme updates are reflected in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->