### PR TITLE
feat (account bug): Fix for dup account issue Double check and fix mu…

### DIFF
--- a/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/IAccountRepository.cs
+++ b/src/Cocktails.Api.Domain/Aggregates/AccountAggregate/IAccountRepository.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cocktails.Api.Domain.Aggregates.AccountAggregate;
 
-using Cocktails.Api.Domain.Aggregates.AccountAggregate;
 using Cocktails.Api.Domain.Common;
 using System.Security.Claims;
 
@@ -12,7 +11,7 @@ public interface IAccountRepository : IRepository<Account>, IReadonlyRepository<
 
     void Update(Account account);
 
-    Task<Account> GetOrCreateLocalAccountFromIdentity(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
+    Task<(Account profile, bool created)> GetOrCreateLocalAccountFromIdentity(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
 
     Task<Account> GetLocalAccountFromIdentity(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
 }

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ManageFavoriteCocktailsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ManageFavoriteCocktailsCommand.cs
@@ -22,11 +22,14 @@ public class ManageFavoriteCocktailsCommandHandler(IAccountRepository accountRep
         Guard.NotNull(command, nameof(command));
         Guard.NotNull(command.Request, nameof(command.Request));
 
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         if (command.Request.CocktailActions != null && command.Request.CocktailActions.Count > 0)
         {

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ProfileImageUploadCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/ProfileImageUploadCommand.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cocktails.Api.Application.Concerns.Accounts.Commands;
 
+using Cezzi.Applications;
 using FluentValidation;
 using global::Cocktails.Api.Application.Concerns.Accounts.Models;
 using global::Cocktails.Api.Application.Utilities;
@@ -32,9 +33,14 @@ public class ProfileImageUploadCommandHandler(
 {
     public async Task<UploadProfileImageRs> Handle(ProfileImageUploadCommand command, CancellationToken cancellationToken)
     {
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
+
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         // Will be used later to destroy the previous blob
         var previousAvatar = account.AvatarUri;

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/RateCocktailCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/RateCocktailCommand.cs
@@ -29,7 +29,7 @@ public class RateCocktailCommandHandler(
 {
     public async Task<RateCocktailRs> Handle(RateCocktailCommand command, CancellationToken cancellationToken)
     {
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
@@ -40,7 +40,10 @@ public class RateCocktailCommandHandler(
             { Monikers.Cocktails.CocktailId, command?.CocktailId }
         });
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         var accountCocktailRatings = !string.IsNullOrWhiteSpace(account.SubjectId)
             ? await accountCocktailRatingsRepository.Items

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/SeedTestAccountCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/SeedTestAccountCommand.cs
@@ -75,7 +75,9 @@ public class SeedTestAccountCommandHandler(
         // ------------------------------------------------------------------
         // If the account has favorite cocktails, start fresh and remove them
         // ------------------------------------------------------------------
-        var favorites = (await accountsQueries.GetAccountOwnedProfile(identity, cancellationToken)).FavoriteCocktails ?? [];
+        var (profile, _) = await accountsQueries.GetAccountOwnedProfile(identity, false, cancellationToken);
+
+        var favorites = profile.FavoriteCocktails ?? [];
         if (favorites.Count > 0)
         {
             var manageFavoriteCocktailsCommand = new ManageFavoriteCocktailsCommand(

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UnRateCocktailCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UnRateCocktailCommand.cs
@@ -29,7 +29,7 @@ public class UnRateCocktailCommandHandler(
 {
     public async Task<bool> Handle(UnRateCocktailCommand command, CancellationToken cancellationToken)
     {
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
@@ -40,7 +40,10 @@ public class UnRateCocktailCommandHandler(
             { Monikers.Cocktails.CocktailId, command?.CocktailId }
         });
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         var accountCocktailRatings = !string.IsNullOrWhiteSpace(account.SubjectId)
             ? await accountCocktailRatingsRepository.Items

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedAccessibilitySettingsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedAccessibilitySettingsCommand.cs
@@ -22,11 +22,14 @@ public class UpdateAccountOwnedAccessibilitySettingsCommandHandler(IAccountRepos
         Guard.NotNull(command, nameof(command));
         Guard.NotNull(command.Request, nameof(command.Request));
 
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         account.SetAccessibilitySettings(theme: (AccessibilityTheme)command.Request.Theme);
         account.SetUpdatedOn(modifiedOn: DateTimeOffset.Now);

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedNotificationSettingsCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedNotificationSettingsCommand.cs
@@ -22,11 +22,14 @@ public class UpdateAccountOwnedNotificationSettingsCommandHandler(IAccountReposi
         Guard.NotNull(command, nameof(command));
         Guard.NotNull(command.Request, nameof(command.Request));
 
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         account.SetOnNewCocktailAdditionsNotification(
             onNewCocktailAdditions: Enum.Parse<CocktailUpdatedNotification>(command.Request.OnNewCocktailAdditions.ToString()));

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileCommand.cs
@@ -31,11 +31,14 @@ public class UpdateAccountOwnedProfileCommandHandler(
         Guard.NotNull(command, nameof(command));
         Guard.NotNull(command.Request, nameof(command.Request));
 
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         account.SetName(givenName: command.Request.GivenName, familyName: command.Request.FamilyName);
         account.SetDisplayName(displayName: command.Request.DisplayName);

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileEmailCommand.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Commands/UpdateAccountOwnedProfileEmailCommand.cs
@@ -22,11 +22,14 @@ public class UpdateAccountOwnedProfileEmailCommandHandler(IAccountRepository acc
         Guard.NotNull(command, nameof(command));
         Guard.NotNull(command.Request, nameof(command.Request));
 
-        var account = await accountRepository.GetOrCreateLocalAccountFromIdentity(
+        var account = await accountRepository.GetLocalAccountFromIdentity(
             claimsIdentity: command.Identity,
             cancellationToken: cancellationToken);
 
-        Guard.NotNull(account);
+        if (account == null)
+        {
+            throw new ArgumentNullException(nameof(account), "Failed to get account from identity.");
+        }
 
         account.SetEmail(email: command.Request.Email);
         account.SetUpdatedOn(modifiedOn: DateTimeOffset.Now);

--- a/src/Cocktails.Api/Application/Concerns/Accounts/Queries/IAccountsQueries.cs
+++ b/src/Cocktails.Api/Application/Concerns/Accounts/Queries/IAccountsQueries.cs
@@ -5,7 +5,7 @@ using System.Security.Claims;
 
 public interface IAccountsQueries
 {
-    Task<AccountOwnedProfileRs> GetAccountOwnedProfile(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
+    Task<(AccountOwnedProfileRs profile, bool created)> GetAccountOwnedProfile(ClaimsIdentity claimsIdentity, bool createIfNotExists, CancellationToken cancellationToken);
 
     Task<AccountCocktailRatingsRs> GetAccountOwnedCocktailRatings(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
 }

--- a/terraform/apim-api.tf
+++ b/terraform/apim-api.tf
@@ -166,6 +166,14 @@ module "apim_cocktails_api" {
       policy_xml_content  = local.apim_anonomous_operation_policy
     },
     {
+      display_name        = "Login Account Owned Profile"
+      method              = "POST"
+      url_template        = "/accounts/owned/profile"
+      description         = "Logs in the logged in users account profile"
+      success_status_code = 200
+      policy_xml_content  = local.apim_anonomous_operation_policy
+    },
+    {
       display_name        = "Get Account Owned Profile"
       method              = "GET"
       url_template        = "/accounts/owned/profile"

--- a/test/Cocktails.Api.Unit.Tests/Apis/Accounts/GetCocktailRatings_Tests.cs
+++ b/test/Cocktails.Api.Unit.Tests/Apis/Accounts/GetCocktailRatings_Tests.cs
@@ -88,7 +88,7 @@ public class GetCocktailRatings_Tests : ServiceTestBase
     }
 
     [Fact]
-    public async Task getcocktailratings__returns_empty_list_for_invalid_user_without_ratings()
+    public async Task getcocktailratings__throws_ratings()
     {
         // Arrange
         var subjectId = GuidString();
@@ -111,11 +111,9 @@ public class GetCocktailRatings_Tests : ServiceTestBase
         var services = GetAsParameterServices<AccountsServices>(sp);
 
         // act
-        var response = (await AccountsApi.GetCocktailRatings(services))?.Result as Ok<AccountCocktailRatingsRs>;
+        var act = async () => await AccountsApi.GetCocktailRatings(services);
 
-        // assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        response.Value.Should().BeEquivalentTo(new AccountCocktailRatingsRs(Ratings: []));
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithMessage("Failed to get account from identity. (Parameter 'account')");
     }
 }

--- a/test/Cocktails.Api.Unit.Tests/Apis/Accounts/LoginAccountOwnedProfile_Tests.cs
+++ b/test/Cocktails.Api.Unit.Tests/Apis/Accounts/LoginAccountOwnedProfile_Tests.cs
@@ -15,12 +15,12 @@ using global::Cocktails.Api.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-public class GetAccountOwnedProfile_Tests : ServiceTestBase
+public class LoginAccountOwnedProfile_Tests : ServiceTestBase
 {
-    public GetAccountOwnedProfile_Tests() { }
+    public LoginAccountOwnedProfile_Tests() { }
 
     [Fact]
-    public async Task getaccountownedprofile__returns_matching_account()
+    public async Task loginaccountownedprofile__returns_matching_account()
     {
         // Arrange
         var (account, claimsIdentity) = GetAccount(GuidString());
@@ -34,7 +34,7 @@ public class GetAccountOwnedProfile_Tests : ServiceTestBase
         var services = GetAsParameterServices<AccountsServices>(sp);
 
         // act
-        var response = await AccountsApi.GetAccountOwnedProfile(services);
+        var response = await AccountsApi.LoginAccountOwnedProfile(services);
         var result = response.Result as Ok<AccountOwnedProfileRs>;
 
         // assert
@@ -44,7 +44,7 @@ public class GetAccountOwnedProfile_Tests : ServiceTestBase
     }
 
     [Fact]
-    public async Task getaccountownedprofile__returns_new_account_when_not_matched()
+    public async Task loginaccountownedprofile__returns_new_account_when_not_matched()
     {
         // Arrange
         var subjectId = GuidString();
@@ -66,12 +66,12 @@ public class GetAccountOwnedProfile_Tests : ServiceTestBase
         var services = GetAsParameterServices<AccountsServices>(sp);
 
         // act
-        var response = await AccountsApi.GetAccountOwnedProfile(services);
-        var result = response.Result as Ok<AccountOwnedProfileRs>;
+        var response = await AccountsApi.LoginAccountOwnedProfile(services);
+        var result = response.Result as Created<AccountOwnedProfileRs>;
 
         // assert
         result.Should().NotBeNull();
-        result.StatusCode.Should().Be(StatusCodes.Status200OK);
+        result.StatusCode.Should().Be(StatusCodes.Status201Created);
         result.Value.Should().BeEquivalentTo(AccountOwnedProfileRs.FromAccount(unmatchedAccount));
     }
 }


### PR DESCRIPTION
…lti-login account issue

Fixes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added POST /accounts/owned/profile to create or log in the signed-in user’s profile (returns 201 when created, 200 when existing).
- Bug Fixes
  - GET /accounts/owned/profile no longer auto-creates a profile; it only retrieves existing data.
  - Endpoints now return clear errors when an account cannot be resolved from the user identity (e.g., ratings retrieval).
- Chores
  - API gateway configuration updated to include the new profile login endpoint.
- Tests
  - Updated unit tests to reflect new endpoint and stricter error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->